### PR TITLE
Fix: WeatherKit 어트리뷰션 지침 및 요구사항 반영

### DIFF
--- a/Dependencies/Models/Sources/Models/Entities/WeatherTrademark.swift
+++ b/Dependencies/Models/Sources/Models/Entities/WeatherTrademark.swift
@@ -1,0 +1,18 @@
+//
+//  WeatherTrademark.swift
+//  Models
+//
+//  Created by Claude on 12/17/25.
+//
+
+import Foundation
+
+public struct WeatherTrademark: Equatable, Sendable {
+    public let imageURL: URL?
+    public let legalPageURL: URL?
+
+    public init(imageURL: URL?, legalPageURL: URL?) {
+        self.imageURL = imageURL
+        self.legalPageURL = legalPageURL
+    }
+}

--- a/Dependencies/WeatherKitService/Sources/WeatherKitService/MockWeatherManager.swift
+++ b/Dependencies/WeatherKitService/Sources/WeatherKitService/MockWeatherManager.swift
@@ -25,4 +25,8 @@ public final class MockWeatherManager: WeatherManagerProtocol {
             windSpeed: Double.random(in: 0.5...5.0)
         )
     }
+
+    public func fetchTrademark() async -> WeatherTrademark {
+        return WeatherTrademark(imageURL: nil, legalPageURL: nil)
+    }
 }

--- a/Dependencies/WeatherKitService/Sources/WeatherKitService/WeatherKitManager.swift
+++ b/Dependencies/WeatherKitService/Sources/WeatherKitService/WeatherKitManager.swift
@@ -42,4 +42,12 @@ public final class WeatherKitManager: WeatherManagerProtocol {
             windSpeed: weather.wind.speed.value
         )
     }
+
+    public func fetchTrademark() async throws -> WeatherTrademark {
+        let attribution = try await weatherService.attribution
+        return WeatherTrademark(
+            imageURL: attribution.combinedMarkLightURL,
+            legalPageURL: attribution.legalPageURL
+        )
+    }
 }

--- a/Dependencies/WeatherKitService/Sources/WeatherKitService/WeatherManagerProtocol.swift
+++ b/Dependencies/WeatherKitService/Sources/WeatherKitService/WeatherManagerProtocol.swift
@@ -11,4 +11,5 @@ import Models
 
 public protocol WeatherManagerProtocol {
     func fetchWeather(for date: Date, location: CLLocationCoordinate2D?) async throws -> WeatherData
+    func fetchTrademark() async throws -> WeatherTrademark
 }

--- a/RunDiary/Resources/Localizable.xcstrings
+++ b/RunDiary/Resources/Localizable.xcstrings
@@ -7,6 +7,29 @@
     "8" : {
 
     },
+    "Apple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple"
+          }
+        }
+      }
+    },
     "difficulty_level.easy" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1824,6 +1847,29 @@
         }
       }
     },
+    "Weather from" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather from"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天気情報提供元"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날씨 정보 제공"
+          }
+        }
+      }
+    },
     "weather.error.api_key_missing" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2032,7 +2078,73 @@
       }
     },
     "설정" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정"
+          }
+        }
+      }
+    },
+    "settings.privacy_policy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy Policy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライバシーポリシー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개인정보처리방침"
+          }
+        }
+      }
+    },
+    "settings.terms_of_service" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terms of Service"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用規約"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이용약관"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/RunDiary/Sources/Clients/WeatherClient/WeatherClient.swift
+++ b/RunDiary/Sources/Clients/WeatherClient/WeatherClient.swift
@@ -14,6 +14,7 @@ import WeatherKitService
 @DependencyClient
 struct WeatherClient {
     var fetchWeather: @MainActor @Sendable (Date, CLLocationCoordinate2D?) async throws -> WeatherData
+    var fetchTrademark: @MainActor @Sendable () async throws -> WeatherTrademark
 }
 
 extension WeatherClient: DependencyKey {
@@ -23,12 +24,16 @@ extension WeatherClient: DependencyKey {
         return WeatherClient(
             fetchWeather: { date, location in
                 try await manager.fetchWeather(for: date, location: location)
+            },
+            fetchTrademark: {
+                try await manager.fetchTrademark()
             }
         )
     }()
 
     static let testValue = WeatherClient(
-        fetchWeather: unimplemented("\(Self.self).fetchWeather")
+        fetchWeather: unimplemented("\(Self.self).fetchWeather"),
+        fetchTrademark: unimplemented("\(Self.self).fetchTrademark")
     )
 
     static let previewValue = WeatherClient(
@@ -38,6 +43,9 @@ extension WeatherClient: DependencyKey {
                 humidity: 60,
                 windSpeed: 2.3
             )
+        },
+        fetchTrademark: {
+            WeatherTrademark(imageURL: nil, legalPageURL: nil)
         }
     )
 }

--- a/RunDiary/Sources/Features/DailyDetail/Core/DailyDetailFeature.swift
+++ b/RunDiary/Sources/Features/DailyDetail/Core/DailyDetailFeature.swift
@@ -20,6 +20,7 @@ struct DailyDetailFeature {
         var dailyRecords: [YearMonthDay: DailyRecord]
         var isLoading: Bool = false
         var error: DailyDetailError? = nil
+        var weatherTrademark: WeatherTrademark? = nil
         @Presents var addRecord: AddRecordFeature.State?
         @Presents var calendar: CalendarFeature.State?
         @Presents var settings: SettingsFeature.State?
@@ -56,6 +57,8 @@ struct DailyDetailFeature {
         case fetchWeekRecords
         case weekRecordsFetched([YearMonthDay: DailyRecord])
         case weekRecordsFetchFailed(DailyDetailError)
+        case fetchWeatherTrademark
+        case weatherTrademarkFetched(WeatherTrademark)
         case createRecord(HealthKitWorkout)
         case editRecord(RunningRecord)
         case addRecord(PresentationAction<AddRecordFeature.Action>)
@@ -68,6 +71,7 @@ struct DailyDetailFeature {
     // MARK: - Dependency
 
     @Dependency(\.runningRecordClient) var runningRecordClient
+    @Dependency(\.weatherClient) var weatherClient
 
     // MARK: - Reducer
 
@@ -81,6 +85,15 @@ struct DailyDetailFeature {
                     state.currentWeekDates = DateHelper.getWeekDates(for: state.selectedDate.toDate()).map { YearMonthDay(date: $0) }
                     AppLogger.dailyDetail.info("주간 날짜 초기화 완료 - 시작일: \(state.currentWeekDates.first ?? nil)")
                 }
+
+                // Fetch trademark only if not already loaded
+                if state.weatherTrademark == nil {
+                    return .merge(
+                        .send(.fetchWeekRecords),
+                        .send(.fetchWeatherTrademark)
+                    )
+                }
+
                 return .send(.fetchWeekRecords)
 
             case let .dateSelected(date):
@@ -164,6 +177,19 @@ struct DailyDetailFeature {
                 state.error = error
                 let errorMessage = error.localizedDescription
                 AppLogger.dailyDetail.error("weekRecordsFetchFailed - error: \(errorMessage)")
+                return .none
+
+            case .fetchWeatherTrademark:
+                AppLogger.dailyDetail.debug("fetchWeatherTrademark 시작")
+
+                return .run { send in
+                    let trademark = try await weatherClient.fetchTrademark()
+                    await send(.weatherTrademarkFetched(trademark))
+                }
+
+            case let .weatherTrademarkFetched(trademark):
+                state.weatherTrademark = trademark
+                AppLogger.dailyDetail.info("weatherTrademarkFetched 완료 - imageURL: \(trademark.imageURL != nil), legalURL: \(trademark.legalPageURL != nil)")
                 return .none
 
             case let .createRecord(healthKitWorkout):

--- a/RunDiary/Sources/Features/DailyDetail/Views/Components/HealthKitWorkoutCard.swift
+++ b/RunDiary/Sources/Features/DailyDetail/Views/Components/HealthKitWorkoutCard.swift
@@ -28,6 +28,7 @@ struct HealthKitWorkoutCard: View {
                     Spacer()
                     Text(workout.startDate.formattedString(formatter: .hourMinutes))
                         .font(.caption)
+                        .foregroundColor(.gray500)
                 }
 
                 HStack(spacing: 20) {

--- a/RunDiary/Sources/Features/DailyDetail/Views/Components/RunningRecordCard.swift
+++ b/RunDiary/Sources/Features/DailyDetail/Views/Components/RunningRecordCard.swift
@@ -22,139 +22,148 @@ struct RunningRecordCard: View {
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            VStack(spacing: 26) {
-                // HealthKit 데이터
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack(spacing: 20) {
-                        RecordVerticalRow(
-                            title: L10n.recordFieldDistance.value,
-                            value: record.distanceInKilometers.to2f
-                        )
-                        RecordVerticalRow(
-                            title: L10n.recordFieldDuration.value,
-                            value: record.formattedDuration
-                        )
-                    }
-
-                    HStack(spacing: 20) {
-                        RecordVerticalRow(
-                            title: L10n.recordFieldPace.value,
-                            value: record.averagePace
-                        )
-                        RecordVerticalRow(
-                            title: L10n.recordFieldHeartRate.value,
-                            value: "\(record.averageHeartRate) bpm"
-                        )
-                    }
-
-                    HStack(spacing: 20) {
-                        RecordVerticalRow(
-                            title: L10n.recordFieldCadence.value,
-                            value: "\(record.averageCadence) spm"
-                        )
-                    }
+            VStack(spacing: 10) {
+                HStack {
+                    Spacer()
+                    Text(record.startTime.formattedString(formatter: .hourMinutes))
+                        .font(.caption)
+                        .foregroundColor(.gray500)
                 }
 
-                if isFolded {
-                    Button {
-                        withAnimation(.linear(duration: 0.2)) {
-                            isFolded = false
-                        }
-                    } label: {
-                        HStack {
-                            Spacer()
-                            L10n.uiViewDetails.text
-                            Image(systemName: "chevron.down")
-                            Spacer()
-                        }
-                        .foregroundStyle(.gray300)
-                    }
-                    .frame(height: 20)
-                } else {
-                    Divider()
-
-                    // 신발
-                    if let shoesId = record.shoes, let shoesName = ShoeStorage.search(id: shoesId)?.name {
-                        RecordHorizontalRow(
-                            title: L10n.recordFieldShoesLabel.value,
-                            value: shoesName
-                        )
-                    }
-
-                    // 주법
-                    if let style = record.runningStyle {
-                        RecordHorizontalRow(
-                            title: L10n.recordFieldRunningStyleLabel.value,
-                            value: style.localizedName
-                        )
-                    }
-
-                    // 통증 부위
-                    if !record.painAreas.isEmpty {
-                        VStack(alignment: .leading, spacing: 8) {
-                            L10n.recordFieldPainAreas.text
-                                .foregroundColor(.gray)
-
-                            DynamicGridLayout(items: record.painAreas) { item in
-                                Text(item.localizedName)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 6)
-                                    .background(Color.blue700.opacity(0.1))
-                                    .foregroundColor(.blue700)
-                                    .cornerRadius(8)
-                            }
-                        }
-                    }
-
-                    Divider()
-
-                    // 날씨 데이터
-                    if let weather = record.weather {
-                        WeatherSectionView(weather: weather)
-                    }
-
-                    Divider()
-
-                    // 수면시간, 식사여부, 음주여부
-                    VStack(alignment: .leading, spacing: 14) {
-                        if let sleep = record.condition.sleep {
-                            RecordHorizontalRow(
-                                title: L10n.recordFieldSleepLabel.value,
-                                value: "\(sleep)시간"
+                VStack(spacing: 26) {
+                    // HealthKit 데이터
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack(spacing: 20) {
+                            RecordVerticalRow(
+                                title: L10n.recordFieldDistance.value,
+                                value: record.distanceInKilometers.to2f
+                            )
+                            RecordVerticalRow(
+                                title: L10n.recordFieldDuration.value,
+                                value: record.formattedDuration
                             )
                         }
 
-                        RecordIconRow(
-                            title: L10n.recordFieldMealLabel.value,
-                            isChecked: record.condition.meal
-                        )
-                        RecordIconRow(
-                            title: L10n.recordFieldAlcoholLabel.value,
-                            isChecked: record.condition.alcohol
-                        )
+                        HStack(spacing: 20) {
+                            RecordVerticalRow(
+                                title: L10n.recordFieldPace.value,
+                                value: record.averagePace
+                            )
+                            RecordVerticalRow(
+                                title: L10n.recordFieldHeartRate.value,
+                                value: "\(record.averageHeartRate) bpm"
+                            )
+                        }
+
+                        HStack(spacing: 20) {
+                            RecordVerticalRow(
+                                title: L10n.recordFieldCadence.value,
+                                value: "\(record.averageCadence) spm"
+                            )
+                        }
                     }
 
-                    // 메모
-                    if let memo = record.condition.memo {
-                        VStack(spacing: 20) {
-                            Image("quotes_leading")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 30)
-                                .opacity(0.3)
-
-                            Text(memo)
-                                .font(.body)
-                                .foregroundColor(.black)
-                                .frame(maxWidth: .infinity)
-
-                            Image("quotes_trailing")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 30)
-                                .opacity(0.3)
+                    if isFolded {
+                        Button {
+                            withAnimation(.linear(duration: 0.2)) {
+                                isFolded = false
+                            }
+                        } label: {
+                            HStack {
+                                Spacer()
+                                L10n.uiViewDetails.text
+                                Image(systemName: "chevron.down")
+                                Spacer()
+                            }
+                            .foregroundStyle(.gray300)
                         }
-                        .padding(.vertical)
+                        .frame(height: 20)
+                    } else {
+                        Divider()
+
+                        // 신발
+                        if let shoesId = record.shoes, let shoesName = ShoeStorage.search(id: shoesId)?.name {
+                            RecordHorizontalRow(
+                                title: L10n.recordFieldShoesLabel.value,
+                                value: shoesName
+                            )
+                        }
+
+                        // 주법
+                        if let style = record.runningStyle {
+                            RecordHorizontalRow(
+                                title: L10n.recordFieldRunningStyleLabel.value,
+                                value: style.localizedName
+                            )
+                        }
+
+                        // 통증 부위
+                        if !record.painAreas.isEmpty {
+                            VStack(alignment: .leading, spacing: 8) {
+                                L10n.recordFieldPainAreas.text
+                                    .foregroundColor(.gray)
+
+                                DynamicGridLayout(items: record.painAreas) { item in
+                                    Text(item.localizedName)
+                                        .padding(.horizontal, 12)
+                                        .padding(.vertical, 6)
+                                        .background(Color.blue700.opacity(0.1))
+                                        .foregroundColor(.blue700)
+                                        .cornerRadius(8)
+                                }
+                            }
+                        }
+
+                        Divider()
+
+                        // 날씨 데이터
+                        if let weather = record.weather {
+                            WeatherSectionView(weather: weather)
+                        }
+
+                        Divider()
+
+                        // 수면시간, 식사여부, 음주여부
+                        VStack(alignment: .leading, spacing: 14) {
+                            if let sleep = record.condition.sleep {
+                                RecordHorizontalRow(
+                                    title: L10n.recordFieldSleepLabel.value,
+                                    value: "\(sleep) \(L10n.unitHours.value)"
+                                )
+                            }
+
+                            RecordIconRow(
+                                title: L10n.recordFieldMealLabel.value,
+                                isChecked: record.condition.meal
+                            )
+                            RecordIconRow(
+                                title: L10n.recordFieldAlcoholLabel.value,
+                                isChecked: record.condition.alcohol
+                            )
+                        }
+
+                        // 메모
+                        if let memo = record.condition.memo {
+                            VStack(spacing: 20) {
+                                Image("quotes_leading")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 30)
+                                    .opacity(0.3)
+
+                                Text(memo)
+                                    .font(.body)
+                                    .foregroundColor(.black)
+                                    .frame(maxWidth: .infinity)
+
+                                Image("quotes_trailing")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 30)
+                                    .opacity(0.3)
+                            }
+                            .padding(.vertical)
+                        }
                     }
                 }
             }

--- a/RunDiary/Sources/Features/DailyDetail/Views/Components/WeatherTrademarkView.swift
+++ b/RunDiary/Sources/Features/DailyDetail/Views/Components/WeatherTrademarkView.swift
@@ -1,0 +1,70 @@
+//
+//  WeatherTrademarkView.swift
+//  RunDiary
+//
+//  Created by Claude on 12/17/25.
+//
+
+import Models
+import SwiftUI
+
+struct WeatherTrademarkView: View {
+    let trademark: WeatherTrademark
+
+    var body: some View {
+        if let legalPageURL = trademark.legalPageURL {
+            Button {
+                UIApplication.shared.open(legalPageURL)
+            } label: {
+                HStack(spacing: 4) {
+                    Text("Weather from")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+
+                    if let imageURL = trademark.imageURL {
+                        AsyncImage(url: imageURL) { phase in
+                            switch phase {
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(height: 14)
+                            case .failure, .empty:
+                                Text("Apple")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(.secondary)
+                            @unknown default:
+                                EmptyView()
+                            }
+                        }
+                    } else {
+                        Text("Apple")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        // With image URL
+        WeatherTrademarkView(
+            trademark: WeatherTrademark(
+                imageURL: URL(string: "https://weatherkit.apple.com/assets/branding/en/Apple_Weather_wx_mark.png"),
+                legalPageURL: URL(string: "https://weatherkit.apple.com/legal-attribution.html")
+            )
+        )
+
+        // Without image URL
+        WeatherTrademarkView(
+            trademark: WeatherTrademark(
+                imageURL: nil,
+                legalPageURL: URL(string: "https://weatherkit.apple.com/legal-attribution.html")
+            )
+        )
+    }
+}

--- a/RunDiary/Sources/Features/DailyDetail/Views/RecordListView.swift
+++ b/RunDiary/Sources/Features/DailyDetail/Views/RecordListView.swift
@@ -29,7 +29,13 @@ struct RecordListView: View {
                     RunningRecordCard(record: record, onEdit: { store.send(.editRecord(record)) })
                 }
 
-                if !dailyRecord.savedRecords.isEmpty && !dailyRecord.healthKitWorkouts.isEmpty {
+                if dailyRecord.hasSavedRecord, let trademark = store.weatherTrademark {
+                    WeatherTrademarkView(trademark: trademark)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .padding(.top, 8)
+                }
+
+                if dailyRecord.hasSavedRecord && dailyRecord.hasHealthKitWorkout {
                     Divider()
                         .padding(.vertical, 10)
                 }

--- a/RunDiary/Sources/Features/Settings/Core/SettingsFeature.swift
+++ b/RunDiary/Sources/Features/Settings/Core/SettingsFeature.swift
@@ -33,8 +33,8 @@ struct SettingsFeature {
 
         var displayName: String {
             switch self {
-            case .privacyPolicy: return "개인정보처리방침"
-            case .termsOfService: return "이용약관"
+            case .privacyPolicy: return L10n.settingsPrivacyPolicy.value
+            case .termsOfService: return L10n.settingsTermsOfService.value
             }
         }
 

--- a/RunDiary/Sources/Generated/L10n.swift
+++ b/RunDiary/Sources/Generated/L10n.swift
@@ -310,6 +310,13 @@ enum L10n {
     static let weatherFieldTemperature: LocalizableKey<LocalizableParameterCount0> = .init(key: "weather.field.temperature")
     /// Wind Speed
     static let weatherFieldWindSpeed: LocalizableKey<LocalizableParameterCount0> = .init(key: "weather.field.wind_speed")
+
+    // MARK: - Settings
+
+    /// Privacy Policy
+    static let settingsPrivacyPolicy: LocalizableKey<LocalizableParameterCount0> = .init(key: "settings.privacy_policy")
+    /// Terms of Service
+    static let settingsTermsOfService: LocalizableKey<LocalizableParameterCount0> = .init(key: "settings.terms_of_service")
 }
 
 // MARK: - Helper

--- a/RunDiary/Sources/SupportingFiles/Info.plist
+++ b/RunDiary/Sources/SupportingFiles/Info.plist
@@ -39,5 +39,7 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/RunDiaryTests/DailyDetailFeatureTests.swift
+++ b/RunDiaryTests/DailyDetailFeatureTests.swift
@@ -30,8 +30,12 @@ struct DailyDetailFeatureTests {
             healthKitWorkouts: [testDate: [mockHealthKit]],
             runningRecords: [testDate: [mockRecord]]
         )
+        let mockTrademark = WeatherTrademark(imageURL: nil, legalPageURL: nil)
 
-        let store = TestStore(initialState: DailyDetailFeature.State(selectedDate: testDate)) {
+        var initialState = DailyDetailFeature.State(selectedDate: testDate)
+        initialState.weatherTrademark = mockTrademark
+
+        let store = TestStore(initialState: initialState) {
             DailyDetailFeature()
         } withDependencies: {
             $0.runningRecordClient.fetchData = { _, _ in expectedDailyRecords }
@@ -602,6 +606,147 @@ struct DailyDetailFeatureTests {
 
         // When & Then
         #expect(store.state.currentDailyRecord == nil)
+    }
+
+    // MARK: - Weather Attribution Tests
+
+    @Test("onAppear 시 weatherTrademark이 nil이면 fetch 트리거")
+    func onAppearWithoutTrademarkFetchesTrademark() async {
+        // Given
+        let testDate = makeTodayYearMonthDay()
+        let expectedTrademark = WeatherTrademark(
+            imageURL: URL(string: "https://example.com/icon.png"),
+            legalPageURL: URL(string: "https://example.com/legal")
+        )
+        let expectedDailyRecords = makeExpectedDailyRecords(
+            forWeekContaining: testDate,
+            healthKitWorkouts: [:],
+            runningRecords: [:]
+        )
+
+        let store = TestStore(initialState: DailyDetailFeature.State(selectedDate: testDate)) {
+            DailyDetailFeature()
+        } withDependencies: {
+            $0.runningRecordClient.fetchData = { _, _ in expectedDailyRecords }
+            $0.weatherClient.fetchTrademark = {
+                expectedTrademark
+            }
+        }
+
+        // When
+        await store.send(.onAppear) {
+            // Then
+            $0.currentWeekDates = makeWeekDates(containing: testDate)
+        }
+
+        await store.receive(\.fetchWeekRecords) {
+            $0.isLoading = true
+            $0.error = nil
+        }
+
+        await store.receive(\.fetchWeatherTrademark)
+
+        await store.receive(\.weekRecordsFetched) {
+            $0.isLoading = false
+            $0.dailyRecords = expectedDailyRecords
+        }
+
+        await store.receive(\.weatherTrademarkFetched) {
+            $0.weatherTrademark = expectedTrademark
+        }
+    }
+
+    @Test("onAppear 시 weatherTrademark이 이미 있으면 fetch 생략")
+    func onAppearWithExistingTrademarkSkipsFetch() async {
+        // Given
+        let testDate = makeTodayYearMonthDay()
+        let existingTrademark = WeatherTrademark(
+            imageURL: URL(string: "https://example.com/icon.png"),
+            legalPageURL: URL(string: "https://example.com/legal")
+        )
+        let expectedDailyRecords = makeExpectedDailyRecords(
+            forWeekContaining: testDate,
+            healthKitWorkouts: [:],
+            runningRecords: [:]
+        )
+
+        var initialState = DailyDetailFeature.State(selectedDate: testDate)
+        initialState.weatherTrademark = existingTrademark
+
+        let store = TestStore(initialState: initialState) {
+            DailyDetailFeature()
+        } withDependencies: {
+            $0.runningRecordClient.fetchData = { _, _ in expectedDailyRecords }
+        }
+
+        // When
+        await store.send(.onAppear) {
+            // Then
+            $0.currentWeekDates = makeWeekDates(containing: testDate)
+        }
+
+        await store.receive(\.fetchWeekRecords) {
+            $0.isLoading = true
+            $0.error = nil
+        }
+
+        await store.receive(\.weekRecordsFetched) {
+            $0.isLoading = false
+            $0.dailyRecords = expectedDailyRecords
+        }
+
+        // No weatherTrademarkFetched action should be received
+        #expect(store.state.weatherTrademark == existingTrademark)
+    }
+
+    @Test("fetchWeatherTrademark 성공 시 State에 trademark 저장")
+    func fetchWeatherTrademarkSuccessSavesTrademark() async {
+        // Given
+        let expectedTrademark = WeatherTrademark(
+            imageURL: URL(string: "https://example.com/icon.png"),
+            legalPageURL: URL(string: "https://example.com/legal")
+        )
+
+        let store = TestStore(initialState: DailyDetailFeature.State()) {
+            DailyDetailFeature()
+        } withDependencies: {
+            $0.weatherClient.fetchTrademark = {
+                expectedTrademark
+            }
+        }
+
+        // When
+        await store.send(.fetchWeatherTrademark)
+
+        // Then
+        await store.receive(\.weatherTrademarkFetched) {
+            $0.weatherTrademark = expectedTrademark
+        }
+    }
+
+    @Test("fetchTrademark가 nil 값 반환 시에도 정상 처리")
+    func fetchWeatherTrademarkHandlesNilValues() async {
+        // Given
+        let expectedTrademark = WeatherTrademark(
+            imageURL: nil,
+            legalPageURL: nil
+        )
+
+        let store = TestStore(initialState: DailyDetailFeature.State()) {
+            DailyDetailFeature()
+        } withDependencies: {
+            $0.weatherClient.fetchTrademark = {
+                expectedTrademark
+            }
+        }
+
+        // When
+        await store.send(.fetchWeatherTrademark)
+
+        // Then
+        await store.receive(\.weatherTrademarkFetched) {
+            $0.weatherTrademark = expectedTrademark
+        }
     }
 
     // MARK: - Error Handling Tests


### PR DESCRIPTION
## 📝 작업 내용

애플 심사에서 WeatherKit 사용에 대한 지침 및 요구사항 미반영으로 인해 리젝을 받았습니다.
이를 반영하기 위해 WeatherKit을 통해 이미지 URL과 법적 사이트 URL을 가져와 일자별 기록 화면에 표기했습니다.

## 🔨 구현 사항

- WeatherKitManagerProtocol에 attribution 페치 동작 추가
- DailyDetailFeature에서 onAppear 동작시 WeatherClient를 통해 attribution 데이터 페치
- 날씨데이터는 로컬에 저장된 기록(일기)에만 포함되기 때문에, 일자별 기록 화면에서 저장된 기록이 존재하는 경우에만 표기
  - 날씨 데이터별로 구분되는 정보가 아니기 때문에, 각 기록 카드에 표기하지 않고 저장된 기록 리스트 하단에 표기
- attribution 아이콘을 탭 했을 때, 외부 브라우저를 통해 legalPostURL로 이동하도록 구현
- 일자별 기록 화면에서 저장된 기록 카드에는 시간이 미표기되어 있어 시간 표기 추가
- 기존 다국어 지원 미반영 텍스트 수정

## ✅ 테스트

- [x] Unit Test 작성/수정
- [x] 수동 테스트 완료
- [ ] SwiftUI Preview 동작 확인
- [ ] 테스트 불필요 (문서/설정 변경 등)

## 📸 스크린샷

| **WeatherKit Attribution 추가** | **저장된 기록에 시간 표기** | **설정화면 다국어 지원** |
| :---: | :---: | :---: |
| ![alt1](https://github.com/user-attachments/assets/653802e8-03cf-4ee4-afee-f0ad6059b0f0) | ![alt2](https://github.com/user-attachments/assets/b3055276-5a5c-46fc-99ae-be9549b3a978) | ![alt3](https://github.com/user-attachments/assets/7e7a3380-7e78-43e8-a83b-e3b073468070) |

## 🔗 관련 이슈

Closes #26 

## 💬 리뷰어에게

- 빠른 심사를 위해 해당 PR은 리뷰 전 머지를 진행하도록 하겠습니다..!!
- attribution이 간단한 값이라서 유틸성 객체를 통해 static 프로퍼티로 접근가능하도록 하는 방법이 고민되었지만, WeatherKit 분리 모듈의 목적이 침해된다고 생각되어 Client를 통해 fetch 하는 방법으로 구현하였습니다. 다만 해당 방법이 적절한지에 대해서는 여전히 확신이 들지 않아 멘토님의 의견이 궁금합니다..!